### PR TITLE
Specify return type of lambda to avoid compiler error.

### DIFF
--- a/renderer/render_view_observer.cc
+++ b/renderer/render_view_observer.cc
@@ -15,7 +15,7 @@ v8::Handle<v8::Value> HelloWorld(v8::Local<v8::String> property, const v8::Acces
 }
 
 v8::Persistent<v8::ObjectTemplate> ConstructorTemplate() {
-  static auto constructor_template = []() {
+  static auto constructor_template = []() -> v8::Persistent<v8::ObjectTemplate> {
     auto constructor_template = v8::Persistent<v8::ObjectTemplate>::New(v8::Isolate::GetCurrent(), v8::ObjectTemplate::New());
     constructor_template->SetAccessor(v8::String::New("helloWorld"), HelloWorld);
     return constructor_template;


### PR DESCRIPTION
Without this change, I receive the following error when attempting
to build: "C++11 requires lambda with omitted result type to consist
of a single return statement"
