### PR TITLE
Use brightray's gyp instead of requiring it to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This is an example app that uses
 ### Prerequisites
 
 * Python 2.7
-* gyp
 * Mac:
     * Xcode
 * Windows:

--- a/script/build
+++ b/script/build
@@ -6,10 +6,7 @@ import sys
 
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-GYP = {
-	'darwin': 'gyp',
-	'win32': 'gyp.bat',
-}[sys.platform]
+GYP = os.path.join(SOURCE_ROOT, 'vendor', 'brightray', 'vendor', 'gyp', 'gyp_main.py')
 
 
 def main():
@@ -19,7 +16,7 @@ def main():
 
 
 def run_gyp():
-    subprocess.check_call([GYP, '--depth', '.', 'brightray_example.gyp'])
+    subprocess.check_call([sys.executable, GYP, '--depth', '.', 'brightray_example.gyp'])
 
 
 def build():


### PR DESCRIPTION
This makes it easier to build brightray_example on a new system.
