### PR TITLE
Fix building errors

### DIFF
--- a/browser/views/window_views.cc
+++ b/browser/views/window_views.cc
@@ -7,6 +7,8 @@
 #include "ui/views/widget/widget.h"
 #include "ui/views/widget/widget_delegate.h"
 
+#include "base/strings/utf_string_conversions.h"
+
 namespace brightray_example {
 
 namespace {
@@ -24,7 +26,9 @@ class WidgetDelegateView : public views::WidgetDelegateView {
   virtual views::View* GetContentsView() OVERRIDE { return this; }
   virtual bool CanResize() const OVERRIDE { return true; }
   virtual bool CanMaximize() const OVERRIDE { return true; }
-  virtual base::string16 GetWindowTitle() const OVERRIDE { return L"Brightray Example";  }
+  virtual base::string16 GetWindowTitle() const OVERRIDE { 
+    return base::ASCIIToUTF16("Brightray Example");  
+  }
   virtual gfx::Size GetPreferredSize() OVERRIDE { return gfx::Size(800, 600); }
   virtual gfx::Size GetMinimumSize() OVERRIDE { return gfx::Size(100, 100); }
 


### PR DESCRIPTION
I still have linking errors you may help me with?

```
spolu@spolu-ThinkPad-T430s:~/src/brightray_example$ ./script/build 
  LINK(target) out/Debug/brightray_example
/usr/bin/ld: /home/spolu/src/brightray_example/vendor/brightray/vendor/download/libchromiumcontent/Release/libchromiumviews.a(gtk2ui.unity_service.o): undefined reference to symbol 'dlsym@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [out/Debug/brightray_example] Error 1
Traceback (most recent call last):
  File "./script/build", line 43, in <module>
    sys.exit(main())
  File "./script/build", line 16, in main
    build()
  File "./script/build", line 33, in build
    subprocess.check_call(['make', '-j%d' % multiprocessing.cpu_count()])
  File "/usr/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['make', '-j4']' returned non-zero exit status 2
spolu@spolu-ThinkPad-T430s:~/src/brightray_example$ 
```
